### PR TITLE
fix(experiments): Validate `rollout_percentage` for both frontend and backend

### DIFF
--- a/ee/clickhouse/views/experiment_holdouts.py
+++ b/ee/clickhouse/views/experiment_holdouts.py
@@ -50,6 +50,16 @@ class ExperimentHoldoutSerializer(serializers.ModelSerializer):
             )
         return updated_filters
 
+    def validate_filters(self, filters):
+        for filter in filters:
+            rollout_percentage = filter.get("rollout_percentage")
+            if rollout_percentage is None:
+                raise serializers.ValidationError("Rollout percentage must be present.")
+            if rollout_percentage < 0 or rollout_percentage > 100:
+                raise serializers.ValidationError("Rollout percentage must be between 0 and 100.")
+
+        return filters
+
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> ExperimentHoldout:
         request = self.context["request"]
         validated_data["created_by"] = request.user

--- a/ee/clickhouse/views/test/test_experiment_holdouts.py
+++ b/ee/clickhouse/views/test/test_experiment_holdouts.py
@@ -144,3 +144,56 @@ class TestExperimentHoldoutCRUD(APILicensedTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["detail"], "Filters are required to create an holdout group")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_holdouts",
+            data={
+                "name": "xyz",
+                "filters": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 150,
+                        "variant": "holdout",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["detail"], "Rollout percentage must be between 0 and 100.")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_holdouts",
+            data={
+                "name": "xyz",
+                "filters": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": -10,
+                        "variant": "holdout",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["detail"], "Rollout percentage must be between 0 and 100.")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_holdouts",
+            data={
+                "name": "xyz",
+                "filters": [
+                    {
+                        "properties": [],
+                        "variant": "holdout",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["detail"], "Rollout percentage must be present.")

--- a/frontend/src/scenes/experiments/Holdouts.tsx
+++ b/frontend/src/scenes/experiments/Holdouts.tsx
@@ -51,6 +51,9 @@ export function Holdouts(): JSX.Element {
         if (holdout.filters?.[0]?.rollout_percentage === undefined) {
             return 'Rollout percentage is required'
         }
+        if (holdout.filters?.[0]?.rollout_percentage < 0 || holdout.filters?.[0]?.rollout_percentage > 100) {
+            return 'Rollout percentage should be between 0 and 100'
+        }
     }
 
     const columns = [


### PR DESCRIPTION
Recreated from original PR: https://github.com/PostHog/posthog/pull/35095

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Closes #35004

## Changes

For frontend, I added a new check to `getDisabledReason` so that users can't submit if `rollout_percentage` is not within 0 to 100.

For backend, added a check for the filters to ensure that all the filters have a valid rollout_percentage.

<img width="790" height="655" alt="Screenshot 2025-07-16...